### PR TITLE
ZOOKEEPER-4474: Drop unused ZooDefs.opNames

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
@@ -161,6 +161,4 @@ public class ZooDefs {
         int persistentRecursive = 1;  // matches AddWatchMode.PERSISTENT_RECURSIVE
     }
 
-    public static final String[] opNames = {"notification", "create", "delete", "exists", "getData", "setData", "getACL", "setACL", "getChildren", "getChildren2", "getMaxChildren", "setMaxChildren", "ping", "reconfig", "getConfig"};
-
 }


### PR DESCRIPTION
Changes:
* Unused `ZooDefs.opNames` dropped.

Author: Kezhu Wang <kezhuw@gmail.com>

Reviewers: maoling <maoling@apache.org>

Closes #1822 from kezhuw/ZOOKEEPER-4474-drop-unused-ZooDefs.opNames
