### PR TITLE
ZOOKEEPER-4464: zooinspector display "Ephemeral Owner" in hex for easy match to jmx session

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerMetaData.java
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerMetaData.java
@@ -118,7 +118,7 @@ public class NodeViewerMetaData extends ZooInspectorNodeViewer {
                     for (Map.Entry<String, String> entry : data.entrySet()) {
                         rowPos = 2 * i + 1;
                         JLabel label = new JLabel(entry.getKey());
-                        JTextField text = new JTextField(entry.getValue());
+                        JTextField text = new JTextField(formatValByKeyType(entry.getKey(),entry.getValue()));
                         text.setEditable(false);
                         GridBagConstraints c1 = new GridBagConstraints();
                         c1.gridx = 0;
@@ -163,6 +163,21 @@ public class NodeViewerMetaData extends ZooInspectorNodeViewer {
                     NodeViewerMetaData.this.metaDataPanel.add(infoPanel, c);
                     NodeViewerMetaData.this.metaDataPanel.revalidate();
                     NodeViewerMetaData.this.metaDataPanel.repaint();
+                }
+
+                private String formatValByKeyType(String key, String value) {
+                    if(key==null) return value;
+                    String formatedVal=value;
+                    switch (key){
+                        case "Ephemeral Owner":
+                            try{
+                                formatedVal = String.format("0x%x", Long.parseLong(value));
+                            }catch (NumberFormatException e){
+                                LoggerFactory.getLogger().warn("parse {}'s value {} to hex fail",key,value,e);
+                            }
+                            break;
+                    }
+                    return formatedVal;
                 }
             };
             worker.execute();


### PR DESCRIPTION
zooinspector now show "Ephemeral Owner" in 10 base number while JMX connections show in hex format. this makes it a little hard to match them.

It will be much better if hex format is shown too, I will create a pr add hex format just beside the 10 based one.

Author: 67 <67@gd67.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Mohammad Arshad <arshad@apache.org>, Mate Szalay-Beko <symat@apache.org>

Closes #1813 from iamgd67/ZOOKEEPER-4464
