### PR TITLE
ZOOKEEPER-4467: Format OpCode.addWatch in Request.op2String

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -355,7 +355,7 @@ public class Request {
             case OpCode.deleteContainer:
                 return "deleteContainer";
             case OpCode.createTTL:
-                return "createTtl";
+                return "createTTL";
             case OpCode.multiRead:
                 return "multiRead";
             case OpCode.auth:
@@ -364,6 +364,8 @@ public class Request {
                 return "setWatches";
             case OpCode.setWatches2:
                 return "setWatches2";
+            case OpCode.addWatch:
+                return "addWatch";
             case OpCode.sasl:
                 return "sasl";
             case OpCode.getEphemerals:

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ToStringTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ToStringTest.java
@@ -18,8 +18,12 @@
 
 package org.apache.zookeeper.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import java.lang.reflect.Field;
 import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.proto.SetDataRequest;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +39,20 @@ public class ToStringTest extends ZKTestCase {
     public void testJuteToString() {
         SetDataRequest req = new SetDataRequest(null, null, 0);
         assertNotSame("ERROR", req.toString());
+    }
+
+    @Test
+    public void testOpCodeToString() throws Exception {
+        Class<?> clazz = ZooDefs.OpCode.class;
+        Field[] fields = clazz.getFields();
+
+        assertNotEquals(0, fields.length);
+
+        for (Field field : fields) {
+            int opCode = field.getInt(null);
+            String opString = Request.op2String(opCode);
+            assertEquals(field.getName(), opString);
+        }
     }
 
 }


### PR DESCRIPTION
Changes:
* Format `OpCode.addWatch` as "addWatch" in `Request.op2String`.

Author: Kezhu Wang <kezhuw@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, maoling <maoling@apache.org>

Closes #1819 from kezhuw/ZOOKEEPER-4467-op_code_addWatch_string and squashes the following commits:

97f891da1 [Kezhu Wang] fixup! ZOOKEEPER-4467: Format OpCode.addWatch in Request.op2String
ebe6faa30 [Kezhu Wang] ZOOKEEPER-4467: Format OpCode.addWatch in Request.op2String
