### PR TITLE
ZOOKEEPER-4514: ClientCnxnSocketNetty throwing NPE

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -304,7 +304,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
      * @return a ChannelFuture that will complete when the write operation
      *         succeeds or fails.
      */
-    private ChannelFuture sendPktAndFlush(Packet p) {
+    private ChannelFuture sendPktAndFlush(Packet p) throws IOException {
         return sendPkt(p, true);
     }
 
@@ -314,7 +314,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
      * @return a ChannelFuture that will complete when the write operation
      *         succeeds or fails.
      */
-    private ChannelFuture sendPktOnly(Packet p) {
+    private ChannelFuture sendPktOnly(Packet p) throws IOException {
         return sendPkt(p, false);
     }
 
@@ -325,7 +325,10 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
         }
     };
 
-    private ChannelFuture sendPkt(Packet p, boolean doFlush) {
+    private ChannelFuture sendPkt(Packet p, boolean doFlush) throws IOException {
+        if (channel == null) {
+            throw new IOException("channel has been closed");
+        }
         // Assuming the packet will be sent out successfully. Because if it fails,
         // the channel will close and clean up queues.
         p.createBB();
@@ -336,7 +339,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
         return result;
     }
 
-    private void sendPrimePacket() {
+    private void sendPrimePacket() throws IOException {
         // assuming the first packet is the priming packet.
         sendPktAndFlush(outgoingQueue.remove());
     }
@@ -344,7 +347,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
     /**
      * doWrite handles writing the packets from outgoingQueue via network to server.
      */
-    private void doWrite(Queue<Packet> pendingQueue, Packet p, ClientCnxn cnxn) {
+    private void doWrite(Queue<Packet> pendingQueue, Packet p, ClientCnxn cnxn) throws IOException {
         updateNow();
         boolean anyPacketsSent = false;
         while (true) {
@@ -374,9 +377,6 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
 
     @Override
     void sendPacket(ClientCnxn.Packet p) throws IOException {
-        if (channel == null) {
-            throw new IOException("channel has been closed");
-        }
         sendPktAndFlush(p);
     }
 


### PR DESCRIPTION
Moved channel object null check to sendPkt method to cover all calling scenarios

Author: Mohammad Arshad <arshad@apache.org>

Reviewers: Mate Szalay-Beko <symat@apache.org>

Closes #1854 from arshadmohammad/ZOOKEEPER-4514-npe
