### PR TITLE
ZOOKEEPER-4549: ProviderRegistry may be repeatedly initialized

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -44,6 +44,9 @@ public class ProviderRegistry {
 
     public static void initialize() {
         synchronized (ProviderRegistry.class) {
+            if (initialized) {
+                return;
+            }
             IPAuthenticationProvider ipp = new IPAuthenticationProvider();
             authenticationProviders.put(ipp.getScheme(), ipp);
 


### PR DESCRIPTION
We run two ZooKeeperServerEmbedded in one JVM and find that ProviderRegistry was initialized repeatedly.

Author: lanicc <lanettiesso@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, tison <wander4096@gmail.com>, maoling <maoling@apache.org>

Closes #1888 from lanicc/ZOOKEEPER-4549
