### PR TITLE
Revert "ZOOKEEPER-4549: ProviderRegistry may be repeatedly initialized"

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -44,9 +44,6 @@ public class ProviderRegistry {
 
     public static void initialize() {
         synchronized (ProviderRegistry.class) {
-            if (initialized) {
-                return;
-            }
             IPAuthenticationProvider ipp = new IPAuthenticationProvider();
             authenticationProviders.put(ipp.getScheme(), ipp);
 


### PR DESCRIPTION
This reverts commit 3fd25d4ebc854328ccc3f8d1c42f6e4c63a84fac.
