### PR TITLE
ZOOKEEPER-3942: move traceMask calculation logic into the trace log guard

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -141,11 +141,11 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 Request request = submittedRequests.take();
                 ServerMetrics.getMetrics().PREP_PROCESSOR_QUEUE_TIME
                     .add(Time.currentElapsedTime() - request.prepQueueStartTime);
-                long traceMask = ZooTrace.CLIENT_REQUEST_TRACE_MASK;
-                if (request.type == OpCode.ping) {
-                    traceMask = ZooTrace.CLIENT_PING_TRACE_MASK;
-                }
                 if (LOG.isTraceEnabled()) {
+                    long traceMask = ZooTrace.CLIENT_REQUEST_TRACE_MASK;
+                    if (request.type == OpCode.ping) {
+                        traceMask = ZooTrace.CLIENT_PING_TRACE_MASK;
+                    }
                     ZooTrace.logRequest(LOG, traceMask, 'P', request, "");
                 }
                 if (Request.requestOfDeath == request) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -323,7 +323,6 @@ public class LearnerHandler extends ZooKeeperThread {
      * @throws InterruptedException
      */
     private void sendPackets() throws InterruptedException {
-        long traceMask = ZooTrace.SERVER_PACKET_TRACE_MASK;
         while (true) {
             try {
                 QuorumPacket p;
@@ -347,13 +346,15 @@ public class LearnerHandler extends ZooKeeperThread {
                     // Packet of death!
                     break;
                 }
-                if (p.getType() == Leader.PING) {
-                    traceMask = ZooTrace.SERVER_PING_TRACE_MASK;
-                }
+
                 if (p.getType() == Leader.PROPOSAL) {
                     syncLimitCheck.updateProposal(p.getZxid(), System.nanoTime());
                 }
                 if (LOG.isTraceEnabled()) {
+                    long traceMask = ZooTrace.SERVER_PACKET_TRACE_MASK;
+                    if (p.getType() == Leader.PING) {
+                        traceMask = ZooTrace.SERVER_PING_TRACE_MASK;
+                    }
                     ZooTrace.logQuorumPacket(LOG, traceMask, 'o', p);
                 }
 
@@ -652,11 +653,11 @@ public class LearnerHandler extends ZooKeeperThread {
                 ia.readRecord(qp, "packet");
                 messageTracker.trackReceived(qp.getType());
 
-                long traceMask = ZooTrace.SERVER_PACKET_TRACE_MASK;
-                if (qp.getType() == Leader.PING) {
-                    traceMask = ZooTrace.SERVER_PING_TRACE_MASK;
-                }
                 if (LOG.isTraceEnabled()) {
+                    long traceMask = ZooTrace.SERVER_PACKET_TRACE_MASK;
+                    if (qp.getType() == Leader.PING) {
+                        traceMask = ZooTrace.SERVER_PING_TRACE_MASK;
+                    }
                     ZooTrace.logQuorumPacket(LOG, traceMask, 'i', qp);
                 }
                 tickOfNextAckDeadline = learnerMaster.getTickOfNextAckDeadline();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
@@ -61,11 +61,11 @@ public class ReadOnlyRequestProcessor extends ZooKeeperCriticalThread implements
                 Request request = queuedRequests.take();
 
                 // log request
-                long traceMask = ZooTrace.CLIENT_REQUEST_TRACE_MASK;
-                if (request.type == OpCode.ping) {
-                    traceMask = ZooTrace.CLIENT_PING_TRACE_MASK;
-                }
                 if (LOG.isTraceEnabled()) {
+                    long traceMask = ZooTrace.CLIENT_REQUEST_TRACE_MASK;
+                    if (request.type == OpCode.ping) {
+                        traceMask = ZooTrace.CLIENT_PING_TRACE_MASK;
+                    }
                     ZooTrace.logRequest(LOG, traceMask, 'R', request, "");
                 }
                 if (Request.requestOfDeath == request) {


### PR DESCRIPTION
Similar to ZOOKEEPER-3708 and ZOOKEEPER-3728 in `Learner`,  I found four cases where `traceMask` calculation logic are out of trace log guard in `LearnerHandler`, `PrepRequestProcessor`, and `ReadOnlyRequestProcessor`. The `traceMask` only matters if trace is enabled, so move the associated code into the logging guard.

Author: coder-chenzhi <zilingqishi@gmail.com>

Reviewers: maoling <maoling199210191@sina.com>

Closes #1464 from coder-chenzhi/master
