### PR TITLE
ZOOKEEPER-4190: Allow log file name to be changed

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -149,7 +149,7 @@ if [ ! -w "$ZOO_LOG_DIR" ] ; then
 mkdir -p "$ZOO_LOG_DIR"
 fi
 
-ZOO_LOG_FILE=zookeeper-$USER-server-$HOSTNAME.log
+ZOO_LOG_FILE=${ZOO_LOG_FILE:-zookeeper-$USER-server-$HOSTNAME.log}
 _ZOO_DAEMON_OUT="$ZOO_LOG_DIR/zookeeper-$USER-server-$HOSTNAME.out"
 
 case $1 in


### PR DESCRIPTION
At the moment the name of the log file is hardcoded and cannot be changed.
With this update, if the variable ZOO_LOG_FILE is present in zookeeper-env.sh, the name of the file can be changed.

Author: tritrimax <tritri24@gmail.com>

Reviewers: Michael Han <hanm@apache.org>, Enrico Olivelli <eolivelli@apache.org>, tison <wander4096@gmail.com>, maoling <maoling199210191@sina.com>

Closes #1439 from tritrimax/patch-1
