### PR TITLE
ZOOKEEPER-4191: Work around missing executable bits in source release tarball

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -692,6 +692,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
symat noticed that the source tarball for 3.7.0rc0 is missing executable bits.

ztzg noticed that this can be worked around by reinstating the "old" version of the maven-assembly-plugin, which had been aligned in ZOOKEEPER-3833.

This patch implements the work around, and also applies cleanly on top of `branch-3.7.0` and `branch-3.7`.

Also discussed on dev:

  https://mail-archives.apache.org/mod_mbox/zookeeper-dev/202101.mbox/%3C875z3n9w75.fsf%40crosstwine.com%3E

Original report:

  https://mail-archives.apache.org/mod_mbox/zookeeper-dev/202101.mbox/%3cCAAMoRKLMf7tLosgqyiwYfFxXq-Zmiz=0oTGDijX5M=MHDF_JCgmail.gmail.com%3e

Author: Damien Diederen <dd@crosstwine.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>

Closes #1586 from ztzg/ZOOKEEPER-4191-missing-x-bits-source-tarball
