### PR TITLE
ZOOKEEPER-3943: Zookeeper Inspector throwing NullPointerExceptions and not displaying properly

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/README.txt
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/README.txt
@@ -18,20 +18,28 @@ Features
 --------
 	Below is a list of features in the current release of ZooInspector.
 	- Load connection settings from a zookeeper properties file
-	- Plugable DataEncryptionManagers to specify how data should be encrypted and decrypted in the Zookeeper instance
-	- Browseable tree view of the ZooKeeper instance
+	- Pluggable DataEncryptionManagers to specify how data should be encrypted and decrypted in the Zookeeper instance
+	- Browsable tree view of the ZooKeeper instance
 	- View the data in a node
-	- View the ACL's currently applied to a node
-	- View the metadata for a node (Version, Number of Children, Last modified Tiem, etc.)
-	- Plugable NodeViewers interface
+	- View the ACLs currently applied to a node
+	- View the metadata for a node (Version, Number of Children, Last modified Time, etc.)
+	- Pluggable NodeViewers interface
 	- Ability to save/load and set default Node Viewers
-	
-Pre-requisites
---------------
-	- The main zookeeper build script must have been run before building this module
-	
-Build Instructions
-------------------
+
+Maven Build Instructions
+-------------------------
+  0. Pre-requisites
+     - Run "mvn install" in the root directory of the Zookeeper project
+  1. Open a command line
+  2. cd into this directory
+  3. mvn install
+  4. To run ZooInspector run zooInspector.cmd (on Windows) or zooInspector.sh (on Linux) (these scripts will
+     find the built JAR automatically in the "target" directory as long as you don't move it)
+
+Ant Build Instructions
+-----------------------
+  0. Pre-requisites
+	   - The main zookeeper build script must have been run before building this module
 	1. Open a command line.
 	2. cd into this directory
 	3. Run command: ant
@@ -40,55 +48,55 @@ Build Instructions
        copied to this directory during the build
 	6. By default the zookeeper.cmd and zookeeper.sh files expect zookeeper-3.3.0.jar.  If you are using another version
 	   you will need to change these files to point to the zookeeper-3.x.x.jar you copied to the lib directory
-	7. To run ZooInspector run zooInspector.cmd (on Windows) or zooInspector.sh (on Linux).  If you are using 
+	7. To run ZooInspector run zooInspector.cmd (on Windows) or zooInspector.sh (on Linux).  If you are using
 	   zookeeper-3.3.0.jar and do not require any classpath changes you can run the zookeeper-dev-ZooInspector.jar
 	   directly
 
 Using ZooInspector
 ------------------
-	To start ZooInspector run zooInspector.cmd (on Windows) or zooInspector.sh (on Linux).  If you are using 
+	To start ZooInspector run zooInspector.cmd (on Windows) or zooInspector.sh (on Linux).  If you are using
 	zookeeper-3.3.0.jar and do not require any classpath changes you can run the zookeeper-dev-ZooInspector.jar
 	directly.
-	
-	Click the play button on the toolbar to bring up the connection dialog.  From here you can enter connection 
-	information for your zookeeper instance.  You can also load the connection properties from a file.  This file can 
+
+	Click the play button on the toolbar to bring up the connection dialog.  From here you can enter connection
+	information for your zookeeper instance.  You can also load the connection properties from a file.  This file can
 	have the format as a normal zookeeper properties file (i.e. hosts and timeout key-value pairs) and van optional have
-	an encryptionManager key-value pair to specify the DataEncryptionManager to use for this connection 
+	an encryptionManager key-value pair to specify the DataEncryptionManager to use for this connection
 	(DataEncryptionManagers are explained in further detail in the 'Creating and Using Plugins' section below).  You can
-	also set the entered information as the defaults so that when you first start ZooInspector these settings are 
+	also set the entered information as the defaults so that when you first start ZooInspector these settings are
 	automatically loaded into this dialog.  Pressing the OK button with connect to your ZooKeeper instance and show the
 	current node tree on the left of the main panel.
-	
-	Clicking a node in the node tree will load the data for that node into the node viewers.  Three node viewers are 
+
+	Clicking a node in the node tree will load the data for that node into the node viewers.  Three node viewers are
 	currently distributed with ZooInspector:
-		1. Node Data - This enables you to see the data current stored on that node.  This data can be modified and 
-		   saved.  The data is decrypted and encrypted using the DataEncryptionManager specified on the connection 
+		1. Node Data - This enables you to see the data current stored on that node.  This data can be modified and
+		   saved.  The data is decrypted and encrypted using the DataEncryptionManager specified on the connection
 		   dialog.
-		2. Node Metadata - This enables you to see the metadata associiated with this node.  This is Essentially the data
+		2. Node Metadata - This enables you to see the metadata associated with this node.  This is essentially the data
 		   obtained from the Stat object for this node.
 		3. Node ACLs - This allows you to see the ACLs currently applied to this node.  Currently there is no ability
 		   to change the ACLs on a node, but it is a feature I would like to add.
 	Other custom Node Viewers can be added, this is explained in the 'Creating and Using Plugins' section below.
-	
+
 
 Creating and Using Plugins
 --------------------------
 	There are two types of plugin which can be used with ZooInspector:
-		1. DataEncryptionManager - This specifies how data should be encrypted and decrypted when working with a 
+		1. DataEncryptionManager - This specifies how data should be encrypted and decrypted when working with a
 		   zookeeper instance.
 		2. ZooInspectorNodeViewer - This is a GUI panel which provides a view of visualisation on a node.
 	More information on these interfaces can be found in the javadocs for this module.
-	
-	To use a plugin in ZooInspector, build the plugin to a jar and copy the jar to the lib sub-directory.  Edit the 
+
+	To use a plugin in ZooInspector, build the plugin to a jar and copy the jar to the lib sub-directory.  Edit the
 	zooInspector.cmd and/or zooInspector.sh files to include your new jar on the classpath and run ZooInspector.
-	
-	For DataEncryptionManagers, click the play button to open the connection dialog and enter the full class name of 
-	your DataEncryptionManager in the 'Data Encryption Manager' field.  You can make this Data Encryption Manager the 
+
+	For DataEncryptionManagers, click the play button to open the connection dialog and enter the full class name of
+	your DataEncryptionManager in the 'Data Encryption Manager' field.  You can make this Data Encryption Manager the
 	default by clicking 'Set As Default'.  Click the 'OK' button to instantiate and use your plugin.
-	
+
 	For ZooInspectorNodeViewers, Click the 'Change Node Viewers' button on the toolbar (looks like a tree with a pencil)
-	and enter the full classname for your Node Viewer in the field left of the 'Add' button, then click the 'Add' 
-	button.  The Node Viewer will be instantiated and should appear in the list.  You can change the order of the Node 
-	viewers by clicking the up and dpwn buttons and delete a Node Viewer by clicking the delete button.  You can save 
+	and enter the full classname for your Node Viewer in the field left of the 'Add' button, then click the 'Add'
+	button.  The Node Viewer will be instantiated and should appear in the list.  You can change the order of the Node
+	viewers by clicking the up and down buttons and delete a Node Viewer by clicking the delete button.  You can save
 	to configuration to a file or set it as the default if necessary. Then click the 'OK' button and your Node Viewer 
 	should appear in the tabs on the right of the main panel.

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -38,6 +38,47 @@
     <guava.version>18.0</guava.version>
   </properties>
 
+  <build>
+    <!-- Ensure "icons" directory is available in built JAR -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>**/*</include>
+        </includes>
+      </resource>
+    </resources>
+    <!-- Allow building of standalone single "fat" jar with all dependencies that allows
+     ZooInspector to build and run standalone. -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <!-- Make the JAR executable via java -jar -->
+          <archive>
+            <manifest>
+              <mainClass>org.apache.zookeeper.inspector.ZooInspector</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/zooInspector.cmd
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/zooInspector.cmd
@@ -14,8 +14,13 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-set CLASSPATH=lib\*;lib
-for /F %%f in ('dir /b "%~dp0%\*.jar" 2^>nul') do (
-   set CLASSPATH=%%f;%CLASSPATH%
+@rem Get the path to the directory containing this script
+SET SCRIPT_DIR=%~dp0
+
+@rem Get the path to the uber jar for this tool
+@rem (Requires "mvn install" or "mvn package" be run first)
+set JAVA_LIB=
+for /F %%f in ('dir /b "%SCRIPT_DIR%\target\zookeeper-contrib-zooinspector-*-jar-with-dependencies.jar" 2^>nul') do (
+   set JAVA_LIB=%SCRIPT_DIR%target\%%f
 )
-java -cp "%CLASSPATH%" org.apache.zookeeper.inspector.ZooInspector
+java -jar %JAVA_LIB%

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/zooInspector.sh
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/zooInspector.sh
@@ -15,4 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-java -cp "zookeeper-dev-ZooInspector.jar:lib/*:lib" org.apache.zookeeper.inspector.ZooInspector
+# Get the path to the directory containing this script
+SCRIPT_DIR=$(dirname "$0")
+
+# Get the path to the uber jar for this tool
+# (Requires "mvn install" or "mvn package" be run first)
+JAVA_LIB=`ls ${SCRIPT_DIR}/target/zookeeper-contrib-zooinspector-*-jar-with-dependencies.jar`
+
+java -jar "${JAVA_LIB}"


### PR DESCRIPTION
ISSUE
---
See https://issues.apache.org/jira/browse/ZOOKEEPER-3943 for details on the issue.

There are two main things being addressed in this PR:

1. The Maven build for ZooInspector seems to generate an invalid JAR file that is missing graphical resources that cause the application to be non-functional (UI does not render properly, NullPointerExceptions occur constantly, etc.).

2. The current Maven build instructions and run scripts for ZooInspector involve building, moving JAR files around, using relative entries on the CLASSPATH and running the scripts from the correct directory in order to use the `zooInspector.sh`/`zooInspector.cmd` launch scripts.

FIXES
---
For number 1, the fix is to add the `src/main/resources/*` directories to the JAR artifact built by Maven.

For number 2, I've proposed changing the Maven build to use the [Maven Assembly Plugin](http://maven.apache.org/plugins/maven-assembly-plugin/) to build a single "fat jar" for ZooInspector that contains all of its dependencies.  The result is that building and running the tool is easier and more straightforward (in my opinion):

```
git clone https://github.com/apache/zookeeper.git
cd zookeeper
mvn install -DskipTests
cd zookeeper-contrib/zookeeper-contrib-zooinspector
mvn install
./zooInspector.sh
```

And based on the "fat jar" style of build and updates to the run scripts, the `zooInspector.sh` and `zooInspector.cmd` commands now successfully execute from any directory (once the project is built) as opposed to requiring you to be in the same directory as the scripts.

My hope is that these changes allow people like myself who are mainly interested in using ZooInspector to easily clone the repository, build and run the tool without any issues.  I spent a chunk of time getting this all working for myself and I hope I can save others some trouble.

TESTING
---
I've tested cloning, building and running ZooInspector on Windows 10, Mac OS X Mojave (10.14.6) and Ubuntu Linux 18.04 using the steps above (on Java 8).

I ran `mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4` in the root directory (per https://cwiki.apache.org/confluence/display/ZOOKEEPER/HowToContribute#HowToContribute-FinalChecksonPullRequest) and got these results:

```
[INFO]
[ERROR] Tests run: 2881, Failures: 4, Errors: 4, Skipped: 4
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ZooKeeper 3.7.0-SNAPSHOT:
[INFO]
[INFO] Apache ZooKeeper ................................... SUCCESS [  7.731 s]
[INFO] Apache ZooKeeper - Documentation ................... SUCCESS [  3.223 s]
[INFO] Apache ZooKeeper - Jute ............................ SUCCESS [ 32.705 s]
[INFO] Apache ZooKeeper - Server .......................... FAILURE [30:28 min]
[INFO] Apache ZooKeeper - Metrics Providers ............... SKIPPED
[INFO] Apache ZooKeeper - Prometheus.io Metrics Provider .. SKIPPED
[INFO] Apache ZooKeeper - Client .......................... SKIPPED
[INFO] Apache ZooKeeper - Client - C ...................... SKIPPED
[INFO] Apache ZooKeeper - Recipes ......................... SKIPPED
[INFO] Apache ZooKeeper - Recipes - Election .............. SKIPPED
[INFO] Apache ZooKeeper - Recipes - Lock .................. SKIPPED
[INFO] Apache ZooKeeper - Recipes - Queue ................. SKIPPED
[INFO] Apache ZooKeeper - Assembly ........................ SKIPPED
[INFO] Apache ZooKeeper - Compatibility Tests ............. SKIPPED
[INFO] Apache ZooKeeper - Compatibility Tests - Curator ... SKIPPED
[INFO] Apache ZooKeeper - Tests ........................... SKIPPED
[INFO] Apache ZooKeeper - Contrib ......................... SKIPPED
[INFO] Apache ZooKeeper - Contrib - Fatjar ................ SKIPPED
[INFO] Apache ZooKeeper - Contrib - Loggraph .............. SKIPPED
[INFO] Apache ZooKeeper - Contrib - Rest .................. SKIPPED
[INFO] Apache ZooKeeper - Contrib - ZooInspector .......... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31:12 min
[INFO] Finished at: 2020-12-05T01:08:27Z
[INFO] ------------------------------------------------------------------------
```
Since all of my proposed changes are in the `zookeeper-contrib` subtree, I'm assuming this doesn't have anything to do with my changes.  Running the same command in the `zookeeper-contrib` directory seems to pass for those tests:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ZooKeeper - Contrib 3.7.0-SNAPSHOT:
[INFO]
[INFO] Apache ZooKeeper - Contrib ......................... SUCCESS [  8.590 s]
[INFO] Apache ZooKeeper - Contrib - Fatjar ................ SUCCESS [ 13.636 s]
[INFO] Apache ZooKeeper - Contrib - Loggraph .............. SUCCESS [ 20.515 s]
[INFO] Apache ZooKeeper - Contrib - Rest .................. SUCCESS [ 13.394 s]
[INFO] Apache ZooKeeper - Contrib - ZooInspector .......... SUCCESS [ 17.056 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:14 min
[INFO] Finished at: 2020-12-05T01:13:22Z
[INFO] ------------------------------------------------------------------------
```

Author: brentwritescode <brentwritescode@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Damien Diederen <ddiederen@apache.org>

Closes #1551 from brentwritescode/master
