### PR TITLE
ZOOKEEPER-4186: update the developer list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,36 @@
         <email>eolivelli@apache.org</email>
         <timezone>+1</timezone>
     </developer>
+    <developer>
+      <id>nkalmar</id>
+      <name>Norbert Kalmar</name>
+      <email>nkalmar@apache.org</email>
+      <timezone>+1</timezone>
+    </developer>
+    <developer>
+      <id>enixon</id>
+      <name>Brian Nixon</name>
+      <email>enixon@apache.org</email>
+      <timezone>-8</timezone>
+    </developer>
+    <developer>
+      <id>symat</id>
+      <name>Mate Szalay-Beko</name>
+      <email>symat@apache.org</email>
+      <timezone>+1</timezone>
+    </developer>
+    <developer>
+      <id>ddiederen</id>
+      <name>Damien Diederen</name>
+      <email>ddiederen@apache.org</email>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+    <developer>
+      <id>maoling</id>
+      <name>Ling Mao</name>
+      <email>maoling@apache.org</email>
+      <timezone>+8</timezone>
+    </developer>
   </developers>
 
   <profiles>


### PR DESCRIPTION
Author: maoling <maoling199210191@sina.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Damien Diederen <ddiederen@apache.org>

Closes #1584 from maoling/ZOOKEEPER-4186 and squashes the following commits:

ad770f25b [maoling] correct the time-zone of Damien Diederen
080a848b3 [maoling] ZOOKEEPER-4186: update the developer list
