### PR TITLE
Revert "ZOOKEEPER-4007: A typo in the ZKUtil#validateFileInput method"

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
@@ -163,7 +163,7 @@ public class ZKUtil {
             return "Read permission is denied on the file '" + file.getAbsolutePath() + "'";
         }
         if (file.isDirectory()) {
-            return "'" + file.getAbsolutePath() + "' is a directory. it must be a file.";
+            return "'" + file.getAbsolutePath() + "' is a direcory. it must be a file.";
         }
         return null;
     }


### PR DESCRIPTION
This reverts commit 4faf507771889c7f6280d41ac4a615467680553f.
