### PR TITLE
ZOOKEEPER-4201: C client: Disable SASL deprecation warnings on macOS

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -948,6 +948,17 @@ int main(int argc, char **argv) {
     zoo_deterministic_conn_order(1); // enable deterministic order
 
 #ifdef HAVE_CYRUS_SASL_H
+    /*
+     * We need to disable the deprecation warnings as Apple has
+     * decided to deprecate all of CyrusSASL's functions with OS 10.11
+     * (see MESOS-3030, ZOOKEEPER-4201). We are using GCC pragmas also
+     * for covering clang.
+     */
+#ifdef __APPLE__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     if (mechlist) {
         zoo_sasl_params_t sasl_params = { 0 };
         int sr;
@@ -977,6 +988,11 @@ int main(int argc, char **argv) {
             return errno;
         }
     }
+
+#ifdef __APPLE__
+#pragma GCC diagnostic pop
+#endif
+
 #endif /* HAVE_CYRUS_SASL_H */
 
     if (!zh) {

--- a/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
@@ -48,6 +48,17 @@
 #include "zookeeper_log.h"
 
 /*
+ * We need to disable the deprecation warnings as Apple has decided to
+ * deprecate all of CyrusSASL's functions with OS 10.11 (see
+ * MESOS-3030, ZOOKEEPER-4201). We are using GCC pragmas also for
+ * covering clang.
+ */
+#ifdef __APPLE__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+/*
  * Store a duplicate of src, or NULL, into *target.  Returns
  * ZSYSTEMERROR if no memory could be allocated, ZOK otherwise.
  */
@@ -539,3 +550,7 @@ sasl_callback_t *zoo_sasl_make_basic_callbacks(const char *user,
         return xcallbacks;
     }
 }
+
+#ifdef __APPLE__
+#pragma GCC diagnostic pop
+#endif

--- a/zookeeper-client/zookeeper-client-c/tests/LibCSymTable.h
+++ b/zookeeper-client/zookeeper-client-c/tests/LibCSymTable.h
@@ -26,6 +26,7 @@
 #include <dlfcn.h>
 #include <cassert>
 #include <poll.h>
+#include <time.h>
 #include <unistd.h> // needed for _POSIX_MONOTONIC_CLOCK
 
 #ifdef THREADED

--- a/zookeeper-client/zookeeper-client-c/tests/TestSASLAuth.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestSASLAuth.cc
@@ -130,6 +130,16 @@ public:
     }
 
 #ifdef HAVE_CYRUS_SASL_H
+
+    // We need to disable the deprecation warnings as Apple has
+    // decided to deprecate all of CyrusSASL's functions with OS 10.11
+    // (see MESOS-3030, ZOOKEEPER-4201). We are using GCC pragmas also
+    // for covering clang.
+#ifdef __APPLE__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     void testClientSASLHelper(const char *hostPorts, const char *path) {
         startServer();
 
@@ -259,6 +269,10 @@ public:
 
         stopServer();
     }
+
+#ifdef __APPLE__
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* HAVE_CYRUS_SASL_H */
 };


### PR DESCRIPTION
This patch works around the numerous deprecation notices added to the CyrusSASL library on macOS.  It is a direct "port" of the solution to MESOS-3030, which hit exactly the same problem:

https://issues.apache.org/jira/browse/MESOS-3030

https://reviews.apache.org/r/39230/diff/3/

The PR also includes a fix for the the `clockid_t` compilation issue mentioned in the ticket description, but the test suite as a whole remains broken on macOS as its linker does not support the `--wrap` option.

Author: Damien Diederen <dd@crosstwine.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Mate Szalay-Beko <symat@apache.org>

Closes #1593 from ztzg/ZOOKEEPER-4201-catalina-c-client-fixes
