### PR TITLE
ZOOKEEPER-4221: Improve the error message when message goes above jute.maxbufer size

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -545,7 +545,10 @@ public class NIOServerCnxn extends ServerCnxn {
             return false;
         }
         if (len < 0 || len > BinaryInputArchive.maxBuffer) {
-            throw new IOException("Len error " + len);
+            throw new IOException("Len error. "
+                    + "A message from " +  this.getRemoteSocketAddress() + " with advertised length of " + len
+                    + " is either a malformed message or too large to process"
+                    + " (length is greater than jute.maxbuffer=" + BinaryInputArchive.maxBuffer + ")");
         }
         if (!isZKServerRunning()) {
             throw new IOException("ZooKeeperServer not running");


### PR DESCRIPTION
Author: Mathieu Marie <mmarie@salesforce.com>

Reviewers: Damien Diederen <dd@crosstwine.com>, Mate Szalay-Beko <symat@apache.org>

Closes #1614 from mariemat/ZOOKEEPER-4221
