### PR TITLE
ZOOKEEPER-4219: Quota checks break setData in multi transactions

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -394,7 +394,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             validatePath(path, request.sessionId);
             nodeRecord = getRecordForPath(path);
             zks.checkACL(request.cnxn, nodeRecord.acl, ZooDefs.Perms.WRITE, request.authInfo, path, null);
-            zks.checkQuota(path, setDataRequest.getData(), OpCode.setData);
+            zks.checkQuota(path, nodeRecord.data, setDataRequest.getData(), OpCode.setData);
             int newVersion = checkAndIncVersion(nodeRecord.stat.getVersion(), setDataRequest.getVersion(), path);
             request.setTxn(new SetDataTxn(path, setDataRequest.getData(), newVersion));
             nodeRecord = nodeRecord.duplicate(request.getHdr().getZxid());
@@ -698,7 +698,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             throw new KeeperException.NoChildrenForEphemeralsException(path);
         }
         int newCversion = parentRecord.stat.getCversion() + 1;
-        zks.checkQuota(path, data, OpCode.create);
+        zks.checkQuota(path, null, data, OpCode.create);
         if (type == OpCode.createContainer) {
             request.setTxn(new CreateContainerTxn(path, data, listACL, newCversion));
         } else if (type == OpCode.createTTL) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -2020,14 +2020,15 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
      * check a path whether exceeded the quota.
      *
      * @param path
-     *            the path of the node
+     *            the path of the node, used for the quota prefix check
+     * @param lastData
+     *            the current node data, {@code null} for none
      * @param data
-     *            the data of the path
+     *            the data to be set, or {@code null} for none
      * @param type
      *            currently, create and setData need to check quota
      */
-
-    public void checkQuota(String path, byte[] data, int type) throws KeeperException.QuotaExceededException {
+    public void checkQuota(String path, byte[] lastData, byte[] data, int type) throws KeeperException.QuotaExceededException {
         if (!enforceQuota) {
             return;
         }
@@ -2043,11 +2044,6 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 checkQuota(lastPrefix, dataBytes, 1);
                 break;
             case OpCode.setData:
-                DataNode node = zkDatabase.getDataTree().getNode(path);
-                byte[] lastData;
-                synchronized (node) {
-                    lastData = node.getData();
-                }
                 checkQuota(lastPrefix, dataBytes - (lastData == null ? 0 : lastData.length), 0);
                 break;
              default:


### PR DESCRIPTION
Without this patch, a multi() transaction such as the one implemented
in ZooKeeperQuotaTest.testMultiCreateThenSetDataShouldWork fails with
MarshallingError when 'enforceQuota' is enabled.

This happens whenever the node has an associated quota, whether it was
exceeded or not.

This is due to the server encountering null while trying to access a
database node by path--whereas that node only exists as a ChangeRecord
in the server's 'outstandingChanges' list:

    java.lang.NullPointerException
        at org.apache.zookeeper.server.ZooKeeperServer.checkQuota(ZooKeeperServer.java:2048)
        at org.apache.zookeeper.server.PrepRequestProcessor.pRequest2Txn(PrepRequestProcessor.java:397)

The patch adds an additional 'lastData' parameter to the quota
checking function, and passes the data from the ChangeRecord during
'setData' operations.

Author: Damien Diederen <dd@crosstwine.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Mate Szalay-Beko <symat@apache.org>, Norbert Kalmar <nkalmar@apache.org>

Closes #1611 from ztzg/ZOOKEEPER-4219-quota-multi-setdata
