### PR TITLE
ZOOKEEPER-4227: X509AuthFailureTest is failing consistently

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/X509AuthFailureTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/X509AuthFailureTest.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.ClientX509Util;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class X509AuthFailureTest {
+public class X509AuthFailureTest extends ZKTestCase {
     protected static final Logger LOG = LoggerFactory.getLogger(X509AuthFailureTest.class);
 
     private static ClientX509Util clientX509Util;
@@ -71,6 +72,8 @@ public class X509AuthFailureTest {
 
         ZooKeeperServerMainTest.MainThread mt = new ZooKeeperServerMainTest.MainThread(CLIENT_PORT, SECURE_CLIENT_PORT, true, null);
         mt.start();
+        assertTrue(
+            ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT, ClientBase.CONNECTION_TIMEOUT));
 
         try {
             ZooKeeper zk = createZKClnt("127.0.0.1:" + SECURE_CLIENT_PORT);


### PR DESCRIPTION
Author: Mohammad Arshad <arshad@apache.org>

Reviewers: Enrico Olivelli <eolivelli@apache.org>

Closes #1616 from arshadmohammad/ZOOKEEPER-4227
