### PR TITLE
ZOOKEEPER-4230: Use dynamic temp folder instead of static temp folder in RestMain

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-rest/src/main/java/org/apache/zookeeper/server/jersey/RestMain.java
+++ b/zookeeper-contrib/zookeeper-contrib-rest/src/main/java/org/apache/zookeeper/server/jersey/RestMain.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,8 @@ public class RestMain {
        System.out.println("Starting grizzly ...");
 
        boolean useSSL = cfg.useSSL();
-       gws = new GrizzlyWebServer(cfg.getPort(), "/tmp/23cxv45345/2131xc2/", useSSL);
+       String zkRestResourcesTempPath = Files.createTempDirectory("zkRestResourcesTempPath").toFile().getCanonicalPath();
+       gws = new GrizzlyWebServer(cfg.getPort(), zkRestResourcesTempPath, useSSL);
        // BUG: Grizzly needs a doc root if you are going to register multiple adapters
 
        for (Endpoint e : cfg.getEndpoints()) {


### PR DESCRIPTION
Author: Mukti <muktikrishnan94@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Mohammad Arshad <arshad@apache.org>

Closes #1633 from MuktiKrishnan/ZOOKEEPER-4230-master
