### PR TITLE
ZOOKEEPER-4205: Change X509AuthFailureTest to use dynamically assigned free port

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/X509AuthFailureTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/X509AuthFailureTest.java
@@ -47,6 +47,7 @@ public class X509AuthFailureTest extends ZKTestCase {
         System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
         System.setProperty(clientX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
         System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty("zookeeper.admin.serverPort", "" + PortAssignment.unique());
     }
 
     @AfterEach
@@ -58,6 +59,7 @@ public class X509AuthFailureTest extends ZKTestCase {
         System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
         System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
         System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
+        System.clearProperty("zookeeper.admin.serverPort");
         clientX509Util.close();
     }
 


### PR DESCRIPTION
…d free port

Author: Amichai Rothman <amichai@apache.org>

Reviewers: Damien Diederen <dd@crosstwine.com>,Andor Molnar <andor@apache.org>,Christopher Tubbs <ctubbsii@apache.org>,Mohammad Arshad <arshad@apache.org>

Closes #1599 from amichair/ZOOKEEPER-4205
