### PR TITLE
ZOOKEEPER-4251: Flaky test: org.apache.zookeeper.test.WatcherTest

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/NettyNettySuiteTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/NettyNettySuiteTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
  * Run tests with: Netty Client against Netty server
  */
 @RunWith(JUnitPlatform.class)
-@SelectClasses({ACLTest.class, AsyncOpsTest.class, ChrootClientTest.class, ClientTest.class, FourLetterWordsTest.class, NullDataTest.class, ReconfigTest.class, SessionTest.class, WatcherTest.class})
+@SelectClasses({ACLTest.class, AsyncOpsTest.class, ChrootClientTest.class, ClientTest.class, FourLetterWordsTest.class, NullDataTest.class, SessionTest.class, WatcherTest.class, ReconfigTest.class})
 public class NettyNettySuiteTest extends NettyNettySuiteBase {
 
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/NioNettySuiteTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/NioNettySuiteTest.java
@@ -23,7 +23,7 @@ import org.junit.runners.Suite;
 /**
  * Run tests with: Nio Client against Netty server
  */
-@Suite.SuiteClasses({ACLTest.class, AsyncOpsTest.class, ChrootClientTest.class, ClientTest.class, FourLetterWordsTest.class, NullDataTest.class, ReconfigTest.class, SessionTest.class, WatcherTest.class})
+@Suite.SuiteClasses({ACLTest.class, AsyncOpsTest.class, ChrootClientTest.class, ClientTest.class, FourLetterWordsTest.class, NullDataTest.class, SessionTest.class, WatcherTest.class, ReconfigTest.class})
 public class NioNettySuiteTest extends NioNettySuiteBase {
 
 }


### PR DESCRIPTION
Moved ReconfigTest in test suites in the last to avoid the ReconfigTest test impacts on other test classes

Author: Mohammad Arshad <arshad@apache.org>

Reviewers: Enrico Olivelli <eolivelli@apache.org>

Closes #1649 from arshadmohammad/ZOOKEEPER-4251-master
