### PR TITLE
ZOOKEEPER-3887: In SSL-only server zkServer.sh status command should use secureClientPortAddress instead of clientPortAddress

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -276,6 +276,11 @@ status)
       if [ "$secureClientPort" ] ; then
         isSSL="true"
         clientPort=$secureClientPort
+        clientPortAddress=`$GREP "^[[:space:]]*secureClientPortAddress[^[:alpha:]]" "$ZOOCFG" | sed -e 's/.*=//'`
+        if ! [ $clientPortAddress ]
+        then
+            clientPortAddress="localhost"
+        fi
       else
         echo "Unable to find either secure or unsecure client port in any configs. Terminating."
         exit 1


### PR DESCRIPTION
Author: Mohammad Arshad <arshad@apache.org>

Reviewers: Mate Szalay-Beko <symat@apache.org>

Closes #1654 from arshadmohammad/ZOOKEEPER-3887-master
