### PR TITLE
ZOOKEEPER-3128: Get CLI Command displays Authentication error for Authorization error

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -90,7 +90,7 @@ public class GetCommand extends CliCommand {
         } catch (IllegalArgumentException ex) {
             throw new MalformedPathException(ex.getMessage());
         } catch (KeeperException | InterruptedException ex) {
-            throw new CliException(ex);
+            throw new CliWrapperException(ex);
         }
         data = (data == null) ? "null".getBytes() : data;
         out.println(new String(data, UTF_8));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
@@ -702,6 +702,13 @@ public class ZooKeeperTest extends ClientBase {
         String zNodeToBeCreated = "/permZNode/child1";
         String errorMessage = executeLine(zkMain, "create " + zNodeToBeCreated);
         assertEquals("Insufficient permission : " + zNodeToBeCreated, errorMessage);
+
+        // Test Get command error message when there is not read access
+        List<ACL> writeAcl = Arrays.asList(new ACL(ZooDefs.Perms.WRITE, Ids.ANYONE_ID_UNSAFE));
+        String noReadPermZNodePath = "/noReadPermZNode";
+        zk.create(noReadPermZNodePath, "newData".getBytes(), writeAcl, CreateMode.PERSISTENT);
+        errorMessage = executeLine(zkMain, "get " + noReadPermZNodePath);
+        assertEquals("Insufficient permission : " + noReadPermZNodePath, errorMessage);
     }
 
     @Test


### PR DESCRIPTION
Handled the scenario missed in ZOOKEEPER-3891

Author: Mohammad Arshad <arshad@apache.org>

Reviewers: Damien Diederen <dd@crosstwine.com>

Closes #1634 from arshadmohammad/ZOOKEEPER-3128-master
