### PR TITLE
ZOOKEEPER-4194: ZooInspector throws NullPointerExceptions to console when node data is null This is a very minor fix to a NullPointerException present in the ZooInspector utility which prevents a NullPointerException getting thrown when ZooInspector inspects an empty node.

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/org/apache/zookeeper/inspector/encryption/BasicDataEncryptionManager.java
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/org/apache/zookeeper/inspector/encryption/BasicDataEncryptionManager.java
@@ -30,6 +30,9 @@ public class BasicDataEncryptionManager implements DataEncryptionManager {
      * (byte[])
      */
     public String decryptData(byte[] encrypted) throws Exception {
+        if(encrypted == null) {
+            return "";
+        }
         return new String(encrypted);
     }
 


### PR DESCRIPTION
Author: brentwritescode <brentwritescode@gmail.com>

Reviewers: Damien Diederen <dd@crosstwine.com>, Mohammad Arshad <arshad@apache.org>

Closes #1601 from brentwritescode/ZOOKEEPER-4194
