### PR TITLE
ZOOKEEPER-4266: Correct ZooKeeper version in documentation header

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/html/header.html
+++ b/zookeeper-docs/src/main/resources/markdown/html/header.html
@@ -36,7 +36,7 @@
                 <a class="unselected" href="https://cwiki.apache.org/confluence/display/ZOOKEEPER/">Wiki</a>
             </li>
             <li class="current">
-                <a class="selected" href="index.html">ZooKeeper 3.6 Documentation</a>
+                <a class="selected" href="index.html">ZooKeeper 3.8 Documentation</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
Changed version from 3.6 to 3.8

Author: Mohammad Arshad <arshad@apache.org>

Reviewers: maoling <maoling@apache.org>, Damien Diederen <ddiederen@apache.org>

Closes #1659 from arshadmohammad/ZOOKEEPER-4266-master
