### PR TITLE
ZOOKEEPER-3961: Improve error message for zookeeper.intBufferStartingSizeBytes config

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -251,7 +251,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         intBufferStartingSizeBytes = Integer.getInteger(INT_BUFFER_STARTING_SIZE_BYTES, DEFAULT_STARTING_BUFFER_SIZE);
 
         if (intBufferStartingSizeBytes < 32) {
-            String msg = "Buffer starting size must be greater than 0."
+            String msg = "Buffer starting size must be greater than or equal to 32."
                          + "Configure with \"-Dzookeeper.intBufferStartingSizeBytes=<size>\" ";
             LOG.error(msg);
             throw new IllegalArgumentException(msg);


### PR DESCRIPTION
… verification.

Author: Ghatage <ghatageanup@gmail.com>

Reviewers: Damien Diederen <ddiederen@apache.org>, Andor Molnar <andor@apache.org>,Enrico Olivelli <eolivelli@apache.org>, Mate Szalay-Beko <symat@apache.org>, maoling <maoling@apache.org>

Closes #1495 from Ghatage/ZOOKEEPER-3961
