### PR TITLE
ZOOKEEPER-4044: Remove unused method and variable

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -323,7 +323,6 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                     Time.currentWallTime(), type));
         }
 
-        PrecalculatedDigest precalculatedDigest;
         switch (type) {
         case OpCode.create:
         case OpCode.create2:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -265,22 +265,6 @@ public class FileSnap implements SnapShot {
         }
     }
 
-    private void writeChecksum(CheckedOutputStream crcOut, OutputArchive oa) throws IOException {
-        long val = crcOut.getChecksum().getValue();
-        oa.writeLong(val, "val");
-        oa.writeString("/", "path");
-    }
-
-    private void checkChecksum(CheckedInputStream crcIn, InputArchive ia) throws IOException {
-        long checkSum = crcIn.getChecksum().getValue();
-        long val = ia.readLong("val");
-        // read and ignore "/" written by writeChecksum
-        ia.readString("path");
-        if (val != checkSum) {
-            throw new IOException("CRC corruption");
-        }
-    }
-
     /**
      * synchronized close just so that if serialize is in place
      * the close operation will block and will wait till serialize


### PR DESCRIPTION
Author: lan <1728209643@qq.com>

Reviewers: maoling <maoling@apache.org>

Closes #1569 from lanicc/ZOOKEEPER-4044 and squashes the following commits:

987680396 [lan] ZOOKEEPER-4044: Remove unused variable in method `PrepRequestProcessor.pRequest2Txn`
646715bbe [lan] ZOOKEEPER-4044: Remove unused method in `FileSnap`
