### PR TITLE
ZOOKEEPER-4275: Prevent unnecessary client connection retry caused by slow SASL login

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -1198,6 +1198,8 @@ public class ClientCnxn {
                         }
                         onConnecting(serverAddress);
                         startConnect(serverAddress);
+                        // Update now to start the connection timer right after we make a connection attempt
+                        clientCnxnSocket.updateNow();
                         clientCnxnSocket.updateLastSendAndHeard();
                     }
 


### PR DESCRIPTION
Slowness in sasl login or subject.doAs() causes zk client to falsely assume that the server did not respond, closes connection and goes to unnecessary retries.

Raising the PR for master - approved for 3.5 branch already.

Author: Ravi Kishore Valeti <v.ravikishore@gmail.com>

Reviewers: Mate Szalay-Beko <symat@apache.org>, Norbert Kalmar <nkalmar@apache.org>, Mohammad Arshad <arshad@apache.org>

Closes #1685 from rvaleti/ZOOKEEPER-4275_master
