### PR TITLE
ZOOKEEPER-3889: Add volatile for variable finished in ReadOnlyRequestProcessor

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
@@ -43,7 +43,7 @@ public class ReadOnlyRequestProcessor extends ZooKeeperCriticalThread implements
 
     private final LinkedBlockingQueue<Request> queuedRequests = new LinkedBlockingQueue<Request>();
 
-    private boolean finished = false;
+    private volatile boolean finished = false;
 
     private final RequestProcessor nextProcessor;
 


### PR DESCRIPTION
Author: dk.technoboy <guo.jiwei@immomo.com>

Reviewers: Michael Han <hanm@apache.org>, Christopher Tubbs <ctubbsii@apache.org>, maoling <maoling@apache.org>

Closes #1402 from Technoboy-/dev
