### PR TITLE
ZOOKEEPER-4280: fix the log format in the DataTree#deserializeZxidDigest method

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -1707,7 +1707,7 @@ public class DataTree {
             if (zxidDigest.zxid > 0) {
                 digestFromLoadedSnapshot = zxidDigest;
                 LOG.info("The digest in the snapshot has digest version of {}, "
-                        + ", with zxid as 0x{}, and digest value as {}",
+                        + "with zxid as 0x{}, and digest value as {}",
                         digestFromLoadedSnapshot.digestVersion,
                         Long.toHexString(digestFromLoadedSnapshot.zxid),
                         digestFromLoadedSnapshot.digest);


### PR DESCRIPTION
Author: fangxiao <fangxiao@kuaishou.com>

Reviewers: maoling <maoling@apache.org>

Closes #1686 from benecdict-fang/ZOOKEEPER-4280
