### PR TITLE
ZOOKEEPER-4312: ZooKeeperServerEmbedded: enhance server start/stop for testability

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/embedded/ZooKeeperServerEmbedded.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/embedded/ZooKeeperServerEmbedded.java
@@ -110,6 +110,22 @@ public interface ZooKeeperServerEmbedded extends AutoCloseable {
     void start() throws Exception;
 
     /**
+     * Start the server
+     * @param startupTimeout time to wait in millis for the server to start
+     * @throws Exception
+     */
+    void start(long startupTimeout) throws Exception;
+
+    /**
+     * Get a connection string useful for the client.
+     * @return the connection string
+     * @throws Exception in case the connection string is not available
+     */
+    String getConnectionString() throws Exception;
+
+    String getSecureConnectionString() throws Exception;
+
+    /**
      * Shutdown gracefully the server and wait for resources to be released.
      */
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1135,7 +1135,6 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
             adminServer.start();
         } catch (AdminServerException e) {
             LOG.warn("Problem starting AdminServer", e);
-            System.out.println(e);
         }
         startLeaderElection();
         startJvmPauseMonitor();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerClusterMutualAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerClusterMutualAuthTest.java
@@ -119,9 +119,9 @@ public class ZookeeperServerClusterMutualAuthTest {
             zkServer2.start();
             zkServer3.start();
 
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientport1, 60000));
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientport2, 60000));
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientport3, 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer1.getConnectionString(), 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer2.getConnectionString(), 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer3.getConnectionString(), 60000));
 
             for (int i = 0; i < 100; i++) {
                 ZookeeperServeInfo.ServerInfo status = ZookeeperServeInfo.getStatus("ReplicatedServer*");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerClusterTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerClusterTest.java
@@ -101,9 +101,9 @@ public class ZookeeperServerClusterTest {
             zkServer2.start();
             zkServer3.start();
 
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientport1, 60000));
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientport2, 60000));
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientport3, 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer1.getConnectionString(), 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer2.getConnectionString(), 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer3.getConnectionString(), 60000));
             for (int i = 0; i < 100; i++) {
                 ZookeeperServeInfo.ServerInfo status = ZookeeperServeInfo.getStatus("ReplicatedServer*");
                 System.out.println("status:" + status);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerEmbeddedTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerEmbeddedTest.java
@@ -59,7 +59,7 @@ public class ZookeeperServerEmbeddedTest {
                 .exitHandler(ExitHandler.LOG_ONLY)
                 .build()) {
             zkServer.start();
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientPort, 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer.getConnectionString(), 60000));
             for (int i = 0; i < 100; i++) {
                 ZookeeperServeInfo.ServerInfo status = ZookeeperServeInfo.getStatus("StandaloneServer*");
                 if (status.isLeader() && status.isStandaloneMode()) {
@@ -71,6 +71,28 @@ public class ZookeeperServerEmbeddedTest {
             assertTrue(status.isLeader());
             assertTrue(status.isStandaloneMode());
         }
+
+        // restart (all ports should be closed and the restart should always work)
+        try (ZooKeeperServerEmbedded zkServer = ZooKeeperServerEmbedded
+                .builder()
+                .baseDir(baseDir)
+                .configuration(configZookeeper)
+                .exitHandler(ExitHandler.LOG_ONLY)
+                .build()) {
+            zkServer.start();
+            assertTrue(ClientBase.waitForServerUp(zkServer.getConnectionString(), 60000));
+            for (int i = 0; i < 100; i++) {
+                ZookeeperServeInfo.ServerInfo status = ZookeeperServeInfo.getStatus("StandaloneServer*");
+                if (status.isLeader() && status.isStandaloneMode()) {
+                    break;
+                }
+                Thread.sleep(100);
+            }
+            ZookeeperServeInfo.ServerInfo status = ZookeeperServeInfo.getStatus("StandaloneServer*");
+            assertTrue(status.isLeader());
+            assertTrue(status.isStandaloneMode());
+        }
+
     }
 
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerSslEmbeddedTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/embedded/ZookeeperServerSslEmbeddedTest.java
@@ -87,7 +87,7 @@ public class ZookeeperServerSslEmbeddedTest {
                 .exitHandler(ExitHandler.LOG_ONLY)
                 .build()) {
             zkServer.start();
-            assertTrue(ClientBase.waitForServerUp("localhost:" + clientPort, 60000));
+            assertTrue(ClientBase.waitForServerUp(zkServer.getConnectionString(), 60000));
             for (int i = 0; i < 100; i++) {
                 ZookeeperServeInfo.ServerInfo status = ZookeeperServeInfo.getStatus("StandaloneServer*");
                 if (status.isLeader() && status.isStandaloneMode()) {
@@ -104,7 +104,7 @@ public class ZookeeperServerSslEmbeddedTest {
             zKClientConfig.setProperty("zookeeper.client.secure", "true");
             // only netty supports TLS
             zKClientConfig.setProperty("zookeeper.clientCnxnSocket", org.apache.zookeeper.ClientCnxnSocketNetty.class.getName());
-            try (ZooKeeper zk = new ZooKeeper("localhost:" + clientSecurePort, 60000, (WatchedEvent event) -> {
+            try (ZooKeeper zk = new ZooKeeper(zkServer.getSecureConnectionString(), 60000, (WatchedEvent event) -> {
                 switch (event.getState()) {
                     case SyncConnected:
                         l.countDown();


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/ZOOKEEPER-4312

ZooKeeperServerEmbedded works well for running ZooKeeper but it lacks support for a few little features in order to use it for tests.

I saw these problems while working on the port of Curator Testing Server to ZooKeeperServerEmbedded.

There is no wait to wait for the server to be up-and-running
When you "close()" the server, it does not wait for the ports to be closed
There is no wait to have the ConnectString for the server

Author: Enrico Olivelli <eolivelli@apache.org>

Reviewers: Damien Diederen <ddiederen@apache.org>

Closes #1710 from eolivelli/impl/embedded-2
