### PR TITLE
ZOOKEEPER-4309: QuorumCnxManager's ListenerHandler thread leak

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -957,8 +957,13 @@ public class QuorumCnxManager {
                                 new ListenerHandler(address, self.shouldUsePortUnification(), self.isSslQuorum(), latch))
                         .collect(Collectors.toList());
 
-                ExecutorService executor = Executors.newFixedThreadPool(addresses.size());
-                listenerHandlers.forEach(executor::submit);
+                final ExecutorService executor = Executors.newFixedThreadPool(addresses.size());
+                try {
+                    listenerHandlers.forEach(executor::submit);
+                } finally {
+                    // prevent executor's threads to leak after ListenerHandler tasks complete
+                    executor.shutdown();
+                }
 
                 try {
                     latch.await();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZOOKEEPER-4309

Author: franz1981 <nigro.fra@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Michael Han <hanm@apache.org>, Damien Diederen <ddiederen@apache.org>

Closes #1705 from franz1981/ZOOKEEPER-4309
