### PR TITLE
ZOOKEEPER-4312: remove unnecessary code

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -976,8 +976,7 @@ public class FastLeaderElection implements Election {
                     /*
                      * Exponential backoff
                      */
-                    int tmpTimeOut = notTimeout * 2;
-                    notTimeout = Math.min(tmpTimeOut, maxNotificationInterval);
+                    notTimeout = Math.min(notTimeout << 1, maxNotificationInterval);
 
                     /*
                      * When a leader failure happens on a master, the backup will be supposed to receive the honour from
@@ -986,8 +985,8 @@ public class FastLeaderElection implements Election {
                      * The leader election algorithm does not provide the ability of electing a leader from a single instance
                      * which is in a configuration of 2 instances.
                      * */
-                    self.getQuorumVerifier().revalidateVoteset(voteSet, notTimeout != minNotificationInterval);
-                    if (self.getQuorumVerifier() instanceof QuorumOracleMaj && voteSet != null && voteSet.hasAllQuorums() && notTimeout != minNotificationInterval) {
+                    if (self.getQuorumVerifier() instanceof QuorumOracleMaj
+                            && self.getQuorumVerifier().revalidateVoteset(voteSet, notTimeout != minNotificationInterval)) {
                         setPeerState(proposedLeader, voteSet);
                         Vote endVote = new Vote(proposedLeader, proposedZxid, logicalclock.get(), proposedEpoch);
                         leaveInstance(endVote);


### PR DESCRIPTION
The result of this line of code is not used, this code is uncessary

Author: zhongxiong.zeng <zhongxiong.zeng@za.group>

Reviewers: Ching-Chan Lee <leechingchankyo@gmail.com>, maoling <maoling@apache.org>

Closes #1709 from zhongxiongzeng/remove_unnecessary_code and squashes the following commits:

2b49e106c [zhongxiong.zeng] Revert "remove redundant code"
081c2a03b [zhongxiong.zeng] remove redundant code
0e8a1ddb2 [zhongxiong.zeng] remove unnecessary code
