### PR TITLE
ZOOKEEPER-4318: Only report the follower sync time metrics if sync is completed

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
@@ -103,16 +103,13 @@ public class Follower extends Learner {
                     throw new IOException("Error: Epoch of leader is lower");
                 }
                 long startTime = Time.currentElapsedTime();
-                try {
-                    self.setLeaderAddressAndId(leaderServer.addr, leaderServer.getId());
-                    self.setZabState(QuorumPeer.ZabState.SYNCHRONIZATION);
-                    syncWithLeader(newEpochZxid);
-                    self.setZabState(QuorumPeer.ZabState.BROADCAST);
-                    completedSync = true;
-                } finally {
-                    long syncTime = Time.currentElapsedTime() - startTime;
-                    ServerMetrics.getMetrics().FOLLOWER_SYNC_TIME.add(syncTime);
-                }
+                self.setLeaderAddressAndId(leaderServer.addr, leaderServer.getId());
+                self.setZabState(QuorumPeer.ZabState.SYNCHRONIZATION);
+                syncWithLeader(newEpochZxid);
+                self.setZabState(QuorumPeer.ZabState.BROADCAST);
+                completedSync = true;
+                long syncTime = Time.currentElapsedTime() - startTime;
+                ServerMetrics.getMetrics().FOLLOWER_SYNC_TIME.add(syncTime);
                 if (self.getObserverMasterPort() > 0) {
                     LOG.info("Starting ObserverMaster");
 


### PR DESCRIPTION
Motivation

- Currently we report the follower sync time regardless whether sync is completed.  This will give us some noisy data such as 0 sync time in cases where sync immediately failed.

Change

- Only report the sync time if the sync is completed.

Author: liwang <liwang@apple.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Michael Han <hanm@apache.org>, Damien Diederen <ddiederen@apache.org>

Closes #1712 from li4wang/ZOOKEEPER-4318
