### PR TITLE
ZOOKEEPER-3961: Improve error message for zookeeper.intBufferStarting…

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -253,7 +253,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         intBufferStartingSizeBytes = Integer.getInteger(INT_BUFFER_STARTING_SIZE_BYTES, DEFAULT_STARTING_BUFFER_SIZE);
 
         if (intBufferStartingSizeBytes < 32) {
-            String msg = "Buffer starting size must be greater than or equal to 32."
+            String msg = "Buffer starting size (" + intBufferStartingSizeBytes + ") must be greater than or equal to 32. "
                          + "Configure with \"-Dzookeeper.intBufferStartingSizeBytes=<size>\" ";
             LOG.error(msg);
             throw new IllegalArgumentException(msg);


### PR DESCRIPTION
…SizeBytes config

Author: Renan Tomazoni Pinzon <rpinzon@gmail.com>

Reviewers: Beluga Behr <dam6923@gmail.com>, maoling <maoling@apache.org>

Closes #1714 from rpinzon/master and squashes the following commits:

1b2c47469 [Renan Tomazoni Pinzon] ZOOKEEPER-3961: Improve error message for zookeeper.intBufferStartingSizeBytes config
f3c5a746b [Renan Tomazoni Pinzon] ZOOKEEPER-3961: Improve error message for zookeeper.intBufferStartingSizeBytes config
